### PR TITLE
feat: add prolog/epilog start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,16 @@ since I'm just adding core functionality, but this would be easy to do.
 
 🚧 Under Development 🚧
 
-*This library has not been tested yet, waiting for development environments!*
+## Orchestration
 
-## TODO
+The following setups are available:
 
-I'm planning to get our testing environment first, and then continue work on this.
-The main deployment question I have to run this in user space (under a batch job)
-is what is the best way to provision the usernetes code. Whatever strategy we choose,
-we want to pin a version (release) that we have tested. But our options are:
+- [flux-framework](scripts/flux): assumes a shared filesystem
+- [aws](scripts/aws): (with Flux, assuming no shared filesystem) is coming soon!
 
-- use a submodule provided here (what I'm implemented now for testing)
-- do a temporary / on the fly clone per job (takes time, but might be the best option)
-- cache something in user's home (only one clone, but could lead to bugs with cleanup, etc.)
+See the logic in [scripts/flux/start-usernetes.sh](scripts/flux/start-usernetes.sh) and [scripts/flux/stop-usernetes.sh](scripts/flux/stop-usernetes.sh) for logic to bring up and down a cluster. For Flux, these are intending to be run as perilog and epilog scripts, before and after a batch job, respectively, and given that a particular environment variable is set. If you add a set of scripts (and instructions) for your environment, please open a pull request here to add code and instructions!
 
-Likely I'll test our the current approach and then choose the second or third bullet. Note
-that what is missing from the code here is the distribution mechanism for the join-command.
-On an HPC cluster we have a shared filesystem (and we are good) but in cloud we need
-a combination of flux archive and flux exec.
+*This library has not been fully tested yet, waiting for development environments!*
 
 ## License
 

--- a/scripts/aws/README.md
+++ b/scripts/aws/README.md
@@ -1,0 +1,240 @@
+# Flux Framework + Usernetes on AWS
+
+This setup has two means to deploy
+
+- On the level of the [system instance](#system-instance) (ideal for experiments)
+- With a [batch job](#batch-job) (to emulate HPC)
+
+The main difference with the second point and an actual HPC system is that we don't assume a shared filesystem here.
+
+## System Instance
+
+#### TLDR
+
+Don't want to read stuff? Here is the whole thing for a system instance level install.
+
+```bash
+usernetes_root=/home/ubuntu/usernetes
+
+# Get the count of worker nodes (minus the lead broker) - you could also just know this :)
+nodes=$(flux hostlist -x $(hostname) local)
+counter=(${nodes//","/ })
+count=${#counter[@]}
+
+# Start the control plane and generate the join-command
+usernetes start-control-plane --workdir $usernetes_root --worker-count ${count} --serial
+
+# Share the join-command with the workers
+flux archive create --name join-command --directory $usernetes_root join-command
+flux exec -x 0 flux archive extract --name join-command --directory $usernetes_root
+flux exec -x 0 usernetes start-worker --workdir $usernetes_root
+
+# Go to town!
+make -C $usernetes_root sync-external-ip
+export KUBECONFIG=/home/ubuntu/usernetes/kubeconfig
+kubectl get nodes
+```
+
+#### Details
+
+The deployment of the system instance is fairly easy - it's going to be starting the control plane, sharing the join-command, and then using flux to exec a command to the workers to do the same.
+
+```bash
+usernetes_root=/home/ubuntu/usernetes
+
+# Get the count of worker nodes (minus the lead broker) - you could also just know this :)
+nodes=$(flux hostlist -x $(hostname) local)
+counter=(${nodes//","/ })
+count=${#counter[@]}
+```
+
+Next we are going to deploy the control plane to the lead broker. We will tell it to deploy in `--serial`, meaning it won't wait for worker nodes to be ready before issuing the last command. We will be issuing the command to deploy the workers, and then the last command to sync.
+
+```bash
+usernetes start-control-plane --workdir $usernetes_root --worker-count ${count} --serial
+```
+
+Now let's create an archive for our join-command, and use flux exec with flux archive to distribute it.
+
+```bash
+flux archive create --name join-command --directory $usernetes_root join-command
+flux exec -x 0 flux archive extract --name join-command --directory $usernetes_root
+```
+
+Now bring up the worker nodes in the same fashion.
+
+```bash
+flux exec -x 0 usernetes start-worker --workdir $usernetes_root
+```
+
+Finally, run the last sync command.
+
+```bash
+make -C $usernetes_root sync-external-ip
+```
+
+Export the kubeconfig, and interact with your cluster.
+
+```bash
+export KUBECONFIG=/home/ubuntu/usernetes/kubeconfig
+kubectl get nodes
+```
+```console
+NAME                      STATUS   ROLES           AGE     VERSION
+u7s-i-0831eed34c13e747e   Ready    control-plane   19m     v1.31.0
+u7s-i-0ac10f9b787d6a349   Ready    <none>          5m26s   v1.31.0
+```
+
+You're in business! User-space Kubernetes is deployed to the system instance. Go nuts. 🥜
+
+## Batch Job
+
+This requires a bit more setup.
+
+> This setup assumes a shared filesystem rooted in `/tmp`.
+
+### Setup
+
+This setup requires perilog and epilog scripts that will setup and teardown userspace
+Kubernetes for a job. We have provided a set of scripts for doing that, and you need to
+provide the prefix to your flux install.
+
+```bash
+git clone https://github.com/converged-computing/usernetes-python
+cd usernetes-python
+python3 -m pip install -e .
+
+# Update the path to usernetes in the (start/stop)-usernetes.sh prolog scripts!
+# /etc/flux/system is the default, so you can also remove it if you are using that.
+./scripts/install-scripts.sh /etc/flux/system
+```
+
+The last step is to configure your flux instance to allow prolog and epilog. Follow [steps two and three here](https://flux-framework.readthedocs.io/projects/flux-core/en/latest/guide/admin.html#adding-job-prolog-epilog-scripts) to edit the broker config. And then see [usage](#usage) for how to submit jobs.
+
+### Usage
+
+#### Testing Usernetes
+
+Here are some helpful commands for using usernetes to get metadata in jobs, either as just the value (attr) or as an export (env). These might go in a batch script, and I'm showing them with flux run so they will function (they rely on either `flux getattr jobid` or an environment variable for a job, which will work for slurm or flux.
+
+```bash
+flux run -N1 usernetes env kubeconfig
+flux run -N1 usernetes attr kubeconfig
+flux run -N1 usernetes env workdir
+flux run -N1 usernetes attr workdir
+```
+
+#### Batch Job
+
+Anything that deploys a job with an epilog or prolog should work, and with one or more instances. Here is a batch script to create on all nodes:
+
+```bash
+#!/bin/bash
+
+# This only works given non-shared filesystem
+# Only rank 0 (lead) will write the kubeconfig
+kubeconfig=$(usernetes attr kubeconfig)
+echo "The kubeconfig is ${kubeconfig}"
+
+# The working directory defaults to $TMPDIR/usernetes-<jobid>
+workdir=$(usernetes attr workdir)
+echo "The working directory is ${workdir}"
+ls $workdir
+
+# Allow worker node to switch from NotReady to Ready
+sleep 10
+if [ -f ${kubeconfig} ]; then
+   echo "Found kubeconfig at $kubeconfig"
+   KUBECONFIG=$kubeconfig kubectl get nodes
+fi
+```
+
+Note that we can use the trick to check for the kubeconfig file here because without a shared filesystem, it will
+only exist on the lead broker (control plane). If you have a shared filesystem, you are going to run that command N times,
+on the control plane and all works. More realistically, you'd probably create a service, and then use it.
+
+```bash
+#!/bin/bash
+
+kubeconfig=$(usernetes attr kubeconfig)
+if [ -f ${kubeconfig} ]; then
+   KUBECONFIG=$kubeconfig kubectl apply -f machine-learning-thing.yaml
+fi
+
+flux run -N 2 python more-machine-learning.py
+```
+
+#### Run or Submit
+
+Run or submit works in a similar way! Let's use the same (or a streamlined) version of the batch.sh script above:
+
+```bash
+#!/bin/bash
+
+kubeconfig=$(usernetes attr kubeconfig)
+# Allow worker node to switch from NotReady to Ready
+sleep 10
+if [ -f ${kubeconfig} ]; then
+   echo "Found kubeconfig at $kubeconfig"
+   KUBECONFIG=$kubeconfig kubectl get nodes
+fi
+```
+
+And then run!
+
+```bash
+flux run -N2 --setattr=attributes.user.usernetes=yes batch.sh
+```
+```console
+flux-job: ƒ2QT1HSJy5 started                                                                                                                                                           00:00:50
+Found kubeconfig at /tmp/usernetes-ƒ2qt1hsjy5/kubeconfig
+NAME                      STATUS   ROLES           AGE   VERSION
+u7s-i-07a51ff87feea61f4   Ready    control-plane   30s   v1.31.2
+u7s-i-0ece5bc9f1d6a38e6   Ready    <none>          18s   v1.31.2
+```
+
+#### Debugging
+
+For any submission means, if you want to debug (meaning creating the setup without allowing the prolog to exit) you can do:
+
+```bash
+flux batch -N2 --setattr=attributes.user.usernetes=yes --setattr=attributes.user.usernetes_debug=yes batch.sh
+```
+
+You'll need to cleanup on your own:
+
+```bash
+docker ps
+docker stop <container>
+docker rm <container>
+
+docker network ls
+docker network rm <network>
+```
+
+If you need to debug, look at `flux dmesg`. Here is what we see when a job is cleaning up:
+
+```console
+...
+2024-12-04T02:11:13.353874Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-0ece5bc9f1d6a38e6 (rank 1): stdout:  Container usernetes-2qt1hsjy5-node-1  Stopping
+2024-12-04T02:11:13.355078Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-07a51ff87feea61f4 (rank 0): stdout:  Container usernetes-2qt1hsjy5-node-1  Stopping
+2024-12-04T02:11:13.794493Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-0ece5bc9f1d6a38e6 (rank 1): stdout:  Container usernetes-2qt1hsjy5-node-1  Stopped
+2024-12-04T02:11:13.794523Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-0ece5bc9f1d6a38e6 (rank 1): stdout:  Container usernetes-2qt1hsjy5-node-1  Removing
+2024-12-04T02:11:13.805416Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-0ece5bc9f1d6a38e6 (rank 1): stdout:  Container usernetes-2qt1hsjy5-node-1  Removed
+2024-12-04T02:11:13.806014Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-0ece5bc9f1d6a38e6 (rank 1): stdout:  Network usernetes-2qt1hsjy5_default  Removing
+2024-12-04T02:11:13.949181Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-0ece5bc9f1d6a38e6 (rank 1): stdout:  Network usernetes-2qt1hsjy5_default  Removed
+2024-12-04T02:11:13.966901Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-0ece5bc9f1d6a38e6 (rank 1): stdout: Successfully brought down User-space Kubernetes for i-0ece5bc9f1d6a38e6, and doing final clean up
+2024-12-04T02:11:18.858445Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-07a51ff87feea61f4 (rank 0): stdout:  Container usernetes-2qt1hsjy5-node-1  Stopped
+2024-12-04T02:11:18.858475Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-07a51ff87feea61f4 (rank 0): stdout:  Container usernetes-2qt1hsjy5-node-1  Removing
+2024-12-04T02:11:18.875432Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-07a51ff87feea61f4 (rank 0): stdout:  Container usernetes-2qt1hsjy5-node-1  Removed
+2024-12-04T02:11:18.876034Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-07a51ff87feea61f4 (rank 0): stdout:  Network usernetes-2qt1hsjy5_default  Removing
+2024-12-04T02:11:19.042701Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-07a51ff87feea61f4 (rank 0): stdout:  Network usernetes-2qt1hsjy5_default  Removed
+2024-12-04T02:11:19.060123Z job-manager.info[0]: ƒ2QT1HSJy5: epilog: i-07a51ff87feea61f4 (rank 0): stdout: Successfully brought down User-space Kubernetes for i-07a51ff87feea61f4, and doing final clean up
+2024-12-04T02:11:19.144581Z sched-simple.debug[0]: free: rank[0-1]/core[0-15] ƒ2QT1HSJy5 (final)
+```
+
+### Issues / Features
+
+ - We should add the container runtime to specify (e.g., docker vs. podman)
+ - It's problematic asking for tasks (e.g., `flux run -N2 -n 32 --setattr=attributes.user.usernetes=yes kubectl get pods`) as 32 instances will be started.
+ - We need to tweak the network namespace, assuming users need to share ports, run more than one, etc.

--- a/scripts/aws/start-usernetes.sh
+++ b/scripts/aws/start-usernetes.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Bring up user-space Kubernetes in a non-shared filesystem (AWS)
+# Variables to add:
+# 1. Runtime (e.g., docker vs. podman)
+# 2. Prolog currently stuck at "found join command" and then no output
+
+# Keep a copy of usernetes you control for users to use - you likely will want to change this
+usernetes_template=/home/ubuntu/usernetes
+
+# We need to get the user id to run commands on their behalf
+user_uid=$(flux job info $FLUX_JOB_ID eventlog | grep submit | jq .context.userid)
+user_id=$(id -nu ${user_uid})
+echo "PATH is $PATH and FLUX_JOB_ID is $FLUX_JOB_ID, running as $(whoami) on behalf of ${user_id}"
+
+# The user is required to set an attribute to indicate wanting usernetes
+run_usernetes=$(flux job info $FLUX_JOB_ID jobspec | jq -r .attributes.user.usernetes)
+if [ "${run_usernetes}" == "" ] || [ "${run_usernetes}" == "null" ]; then
+    echo "User does not want to deploy User-space Kubernetes"
+    exit 0
+fi
+echo "User has indicated wanting to deploy User-space Kubernetes"
+
+# Get the kvs for the job so we can set metadata there
+kvs_path=$(flux job id --to=kvs ${FLUX_JOB_ID})
+
+# Get the nodelist from the jobid
+# nodes=$(flux job info $FLUX_JOB_ID R | jq -r .execution.nodelist[0])
+nodes=$(flux hostlist ${FLUX_JOB_ID})
+echo "Found nodes ${nodes} in Job ${FLUX_JOB_ID}"
+
+# Count the nodes (including control plane)
+count=$(flux getattr size)
+worker_count=$(flux hostlist -x $(hostname) --count local)
+echo "Found ${count} total nodes, and ${worker_count} not including the control plane"
+
+# Get the lead broker (control plane) and worker ids
+lead_broker=$(flux hostlist -n 0 local)
+rank=$(hostname)
+echo "The lead broker is ${lead_broker}"
+
+# We need a predictable way to name a usernetes root.
+tmpdir=$(dirname $(mktemp -u))
+jobid=$(echo ${FLUX_JOB_ID} | tr '[:upper:]' '[:lower:]')
+usernetes_root=${tmpdir}/usernetes-${jobid}
+echo "Usernetes will be staged in ${usernetes_root}"
+
+# I am not assuming this is shared across nodes
+flux kvs put ${kvs_path}.usernetes=yes
+flux kvs put ${kvs_path}.usernetes_root=${usernetes_root}
+
+# This is for the user
+sudo -u ${user_id} flux kvs put ${kvs_path}.user.usernetes_root=${usernetes_root}
+
+# If we don't remove the created tmpdir, it will copy inside of it
+rm -rf $usernetes_root
+cp -R $usernetes_template $usernetes_root
+chown -R $user_id $usernetes_root
+
+# Use the tmpdir name to generate an archive name
+usernetes_uid=$(basename $usernetes_root)
+archive_name=${usernetes_uid}-join-command
+echo "Archive name for sharing join-command is ${archive_name}"
+
+# Ensure the network is not up
+network_name=${usernetes_uid}_default
+sudo -u ${user_id} docker network rm ${network_name} || true
+
+# Debug mode - we sleep here
+debug_mode=$(flux job info $FLUX_JOB_ID jobspec | jq -r .attributes.user.usernetes_debug)
+if [ "${debug_mode}" != "null" ]; then
+    echo "Entering debug mode for ${usernetes_root}, sleeping infinity"
+    sleep infinity
+fi
+
+# Do all orchestration from control plane. This uses the docker-compose.yaml provided by usernetes
+# The two scripts handle orchestration of waiting for the other.
+if [ "${rank}" == "${lead_broker}" ]; then
+    # The main difference between here and the shared filesystem is that we need to run in serial,
+    # distribute the join-command, and wait for the correct number of instance names to show up
+    sudo -u ${user_id} usernetes --develop start-control-plane --workdir $usernetes_root --worker-count ${worker_count} --serial
+    flux archive create --name ${archive_name} --directory $usernetes_root join-command
+    flux exec -x 0 flux archive extract --name ${archive_name} --directory $usernetes_root
+
+    # Wait for workers - this needs to equal the worker count. We do this because
+    # the filesystem is not shared, which is how the wait-workers command works
+    while true; do
+        echo "Checking for ${worker_count} workers to be ready..."
+        ready_count=$(flux kvs dir ${kvs_path}.usernetes_ready | wc -l)
+        sleep 5
+        if [ "${ready_count}" == "${worker_count}" ]; then
+            echo "⭐ ${ready_count} workers are ready."
+            break
+        fi
+    done
+
+    # One last sync is needed
+    sudo -u ${user_id} make -C $usernetes_root sync-external-ip
+else
+    # We don't need to do anything special here, it will still wait for the join command
+    sudo -u ${user_id} usernetes start-worker --workdir $usernetes_root
+    # When this command finishes, the worker is as ready as it can be.
+    # Add this to the ready kvs directory.
+    broker_rank=$(flux getattr rank)
+    flux kvs put ${kvs_path}.usernetes_ready.${broker_rank}=yes
+fi
+export KUBECONFIG=$usernetes_root/kubeconfig

--- a/scripts/aws/stop-usernetes.sh
+++ b/scripts/aws/stop-usernetes.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# TODO we need different activity based on batch or submit, batch
+# seems to be seeing the same network?
+
+echo "The current path is $PATH"
+echo "The FLUX_JOB_ID is $FLUX_JOB_ID"
+
+# The user is required to set an attribute to indicate wanting usernetes
+run_usernetes=$(flux job info $FLUX_JOB_ID jobspec | jq -r .attributes.user.usernetes)
+if [ "${run_usernetes}" == "" ] || [ "${run_usernetes}" == "null" ]; then
+    echo "User does not want to deploy User-space Kubernetes"
+    exit 0
+fi
+
+# We need to get the user id to run commands on their behalf
+user_uid=$(flux job info $FLUX_JOB_ID eventlog | grep submit | jq .context.userid)
+user_id=$(id -nu ${user_uid})
+echo "User ${user_id} has indicated User-space Kubernetes deployment"
+
+# Get the kvs for the job so we can set metadata there
+kvs_path=$(flux job id --to=kvs ${FLUX_JOB_ID})
+usernetes_root=$(flux kvs get ${kvs_path}.usernetes_root)
+
+# Bring the cluster down, and it doesn't matter what the node name is (same command for all)
+sudo -u ${user_id} usernetes --develop down --workdir $usernetes_root
+if [  $? -eq 0 ]; then
+   echo "Successfully brought down User-space Kubernetes for $(hostname), and doing final clean up"
+   # This can also be done with usernetes clean --all
+   # We assume a shared filesystem and issue this just once
+   # TODO test the clean without root (and see if containers AND filesystem cleans up)
+   sudo -u ${user_id} usernetes --develop clean --workdir $usernetes_root
+   rm -rf ${usernetes_root}
+else
+   echo "Issue bringing down User-space Kubernetes, root left at ${usernetes_root}"
+fi

--- a/scripts/flux/README.md
+++ b/scripts/flux/README.md
@@ -1,0 +1,39 @@
+# Flux Framework + Usernetes
+
+> This setup assumes a shared filesystem rooted in `/tmp`.
+
+**IMPORTANT** we don't have a development environment for this yet, so it isn't finished.
+The [aws setup](../aws) without a shared filesystem is testing and working, with more complete documentation in the README there.
+
+## Setup
+
+You'll want to first create the appropriate perilog and epilog scripts that will setup and teardown userspace
+Kubernetes for a job. Here is an example for how to do that (and you only need to do this once) for a system
+that has flux system configuration in `/etc/flux`. First, let's copy the script included here to
+a file named "prolog" in `/etc/flux/system` and create a subdirectory for our prolog scripts.
+
+```bash
+mkdir -p /etc/flux/system/prolog.d /etc/flux/system/epilog.d
+```
+
+We assume you have cloned usernetes-python and are sitting at the root.
+These top level scripts will be run, and execute those in `(epilog|prolog).d`
+There is a script provided to install usernetes to where your system (root) will see it, along
+with prolog/epilog scripts to your flux system configuration root, which defaults
+to `/etc/flux/system`.
+
+```bash
+/bin/bash ./scripts/install-scripts.sh /etc/flux/system
+```
+
+For batch jobs that want to deploy and teardown. The last step is to configure your flux instance to allow prolog and epilog. Follow [steps two and three here](https://flux-framework.readthedocs.io/projects/flux-core/en/latest/guide/admin.html#adding-job-prolog-epilog-scripts) to edit the broker config.
+
+## Usage
+
+Anything that deploys a job with an epilog or prolog should work, and with one or more instances.
+
+```bash
+flux batch -N4 --setattr=attributes.user.usernetes=yes kubectl get pods
+flux submit -N4 --setattr=attributes.user.usernetes=yes kubectl get pods
+flux run -N4 --setattr=attributes.user.usernetes=yes kubectl get pods
+```

--- a/scripts/flux/start-usernetes.sh
+++ b/scripts/flux/start-usernetes.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+echo "The current path is $PATH"
+echo "The FLUX_JOB_ID is $FLUX_JOB_ID"
+
+# Keep a copy of usernetes you control for users to use
+# **You likely will want to change this.
+usernetes_template=/home/ubuntu/usernetes
+
+# The user is required to set an attribute to indicate wanting usernetes
+run_usernetes=`flux job info $FLUX_JOB_ID jobspec | jq -r .attributes.user.usernetes`
+if [ "${run_usernetes}" == "" ] || [ "${run_usernetes}" == "null" ]; then
+    echo "User does not want to deploy User-space Kubernetes"
+    exit 0
+fi
+
+echo "User has indicated wanting to deploy User-space Kubernetes"
+
+# Get the kvs for the job so we can set metadata there
+usernetes_root=$(mktemp -d -t usernetes-XXXXXX)
+kvs_path=$(flux job id --to=kvs ${FLUX_JOB_ID})
+flux kvs put ${kvs_path}.usernetes=yes
+flux kvs put ${kvs_path}.usernetes_root=${usernetes_root}
+
+# Get the nodelist from the jobid
+nodes=$(flux job info $FLUX_JOB_ID R | jq -r .execution.nodelist[0])
+echo "Found nodes ${nodes} in Job ${FLUX_JOB_ID}"
+
+# Count the nodes (including control plane)
+worker_count=$(flux hostlist -x $(hostname) --count local)
+echo "Found ${count} total nodes, and ${worker_count} not including the control plane"
+
+# Get the lead broker (control plane) and worker ids
+lead_broker=$(echo "$nodes" | cut -d ',' -f 1)
+rank=$(hostname)
+
+# If we don't remove the created tmpdir, it will copy inside of it
+# IMPORTANT: this directory needs to exist on the workers too
+flux exec -r all rm -rf $usernetes_root
+flux exec -r all cp -R $usernetes_template $usernetes_root
+echo "Usernetes will be staged in ${usernetes_root}"
+
+# Do all orchestration from control plane. This uses the docker-compose.yaml provided by usernetes
+# The two scripts handle orchestration of waiting for the other.
+if [ "${rank}" == "${lead_broker}" ]; then
+    usernetes --develop start-control-plane --workdir $usernetes_root --worker-count ${worker_count}
+else
+    usernetes --develop start-worker --workdir $usernetes_root
+fi
+export KUBECONFIG=$usernetes_root/kubeconfig

--- a/scripts/flux/stop-usernetes.sh
+++ b/scripts/flux/stop-usernetes.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "The current path is $PATH"
+echo "The FLUX_JOB_ID is $FLUX_JOB_ID"
+
+# The user is required to set an attribute to indicate wanting usernetes
+run_usernetes=`flux job info $FLUX_JOB_ID jobspec | jq -r .attributes.user.usernetes`
+if [ "${run_usernetes}" == "" ] || [ "${run_usernetes}" == "null" ]; then
+    echo "User does not want to deploy User-space Kubernetes"
+    exit 0
+fi
+
+echo "User has indicated User-space Kubernetes deployment"
+
+# Get the kvs for the job so we can set metadata there
+kvs_path=$(flux job id --to=kvs ${FLUX_JOB_ID})
+usernetes_root=$(flux kvs get ${kvs_path}.usernetes_root)
+
+# Bring the cluster down, and it doesn't matter what the node name is (same command for all)
+usernetes --develop down --workdir $usernetes_root
+if [  $? -eq 0 ]; then
+   echo "Successfully brought down User-space Kubernetes, and doing final clean up"
+   # This can also be done with usernetes clean --all
+   # We assume a shared filesystem and issue this just once
+   rm -rf $usernetes_root
+else
+   echo "Issue bringing down User-space Kubernetes, root left at ${usernetes_root}"
+fi

--- a/scripts/install-scripts.sh
+++ b/scripts/install-scripts.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+here=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Install scripts to flux root. Requires sudo
+flux_system_root=${1:-/etc/flux/system}
+echo "Flux install root is ${flux_system_root}, cancel in 3 seconds if wrong."
+sleep 3
+
+# Important! The path for the prolog runner is /usr/sbin:/usr/bin:/sbin:/bin
+sudo cp $(which usernetes) /usr/bin/usernetes
+
+# Setup prolog/epilog
+mkdir -p ${flux_system_root}/prolog.d ${flux_system_root}/epilog.d
+sudo cp ${here}/shared/prolog.sh ${flux_system_root}/prolog
+sudo cp ${here}/shared/epilog.sh ${flux_system_root}/epilog
+sudo cp ${here}/aws/start-usernetes.sh ${flux_system_root}/prolog.d/start-usernetes.sh
+sudo cp ${here}/aws/stop-usernetes.sh ${flux_system_root}/epilog.d/stop-usernetes.sh
+
+# These are for the control plane and others
+sudo chmod +x ${flux_system_root}/epilog ${flux_system_root}/prolog ${flux_system_root}/*/*.sh

--- a/scripts/shared/epilog.sh
+++ b/scripts/shared/epilog.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+exit_rc=0
+periname=epilog
+peridir=/etc/flux/system/${periname}.d
+
+# This script may be run in test with 'sudo flux run-prolog'
+test $FLUX_JOB_USERID && userid=$(id -n -u $FLUX_JOB_USERID 2>/dev/null)
+echo Running $periname for ${FLUX_JOB_ID:-unknown}/${userid:-unknown}
+
+for file in ${peridir}/*; do
+    test -e $file || continue
+    name=$(basename $file)
+    echo running $name >&2
+    $file
+    rc=$?
+    test $rc -ne 0 && echo "$name exit $rc" >&2
+    test $rc -gt $exit_rc && exit_rc=$rc
+done
+
+exit $exit_rc

--- a/scripts/shared/prolog.sh
+++ b/scripts/shared/prolog.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+exit_rc=0
+periname=prolog
+peridir=/etc/flux/system/${periname}.d
+
+# This script may be run in test with 'sudo flux run-prolog'
+test $FLUX_JOB_USERID && userid=$(id -n -u $FLUX_JOB_USERID 2>/dev/null)
+echo Running $periname for ${FLUX_JOB_ID:-unknown}/${userid:-unknown}
+
+for file in ${peridir}/*; do
+    test -e $file || continue
+    name=$(basename $file)
+    echo running $name >&2
+    $file
+    rc=$?
+    test $rc -ne 0 && echo "$name exit $rc" >&2
+    test $rc -gt $exit_rc && exit_rc=$rc
+done
+
+exit $exit_rc

--- a/usernetes/cli/__init__.py
+++ b/usernetes/cli/__init__.py
@@ -18,12 +18,17 @@ def get_parser():
     # Global Variables
     parser.add_argument(
         "--debug",
-        dest="debug",
         help="use verbose logging to debug.",
         default=False,
         action="store_true",
     )
 
+    parser.add_argument(
+        "--develop",
+        help="Don't wrap main in a try except (allow error to come through)",
+        default=False,
+        action="store_true",
+    )
     parser.add_argument(
         "--quiet",
         dest="quiet",
@@ -56,16 +61,68 @@ def get_parser():
         formatter_class=argparse.RawTextHelpFormatter,
         description="start user-space Kubernetes control plane (akin to 'up')",
     )
-    for start in [start_worker, start_control]:
-        start.add_argument(
-            "config",
-            help="config file (defaults to usernetes release)",
-            default=defaults.compose_file,
+    start_control.add_argument(
+        "--serial",
+        help="Serial execution mode (do not wait for workers to come up)",
+        action="store_true",
+        default=False,
+    )
+    down = subparsers.add_parser(
+        "down",
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Bring down a node",
+    )
+    wait = subparsers.add_parser(
+        "wait-workers",
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Wait for workers and sync ip address when ready.",
+    )
+    # Env and attributes are obtainable from the instance.
+    # E.g., we assume we can run flux getattr and similar.
+    attribute = subparsers.add_parser(
+        "attr",
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Derive attributes",
+    )
+    envars = subparsers.add_parser(
+        "env",
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Derive environment variables",
+    )
+    for command in [attribute, envars]:
+        command.add_argument(
+            "attributes",
+            action="append",
+            default=[],
+            help="Return (by default) kubeconfig and workdir",
         )
-        start.add_argument(
+    clean = subparsers.add_parser(
+        "clean",
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Clean the worker cache (to prepare for another job)",
+    )
+    clean.add_argument(
+        "--keep-node",
+        dest="keep_node",
+        help="Do not remove the node (requires keeping the workdir)",
+    )
+    for command in [start_control, clean]:
+        command.add_argument(
+            "--all",
+            dest="clean_all",
+            help="Also remove the entire usernetes root (not just worker cache)",
+            action="store_true",
+            default=False,
+        )
+    for command in [start_worker, start_control, wait, down, clean]:
+        command.add_argument(
             "--workdir",
             help="working directory with docker-compose.yaml",
-            default=defaults.usernetes_root,
+        )
+    for command in [start_control, wait]:
+        command.add_argument(
+            "--worker-count",
+            help="worker count (not including control plane)",
         )
     return parser
 
@@ -109,6 +166,20 @@ def run_usernetes():
     # Here we can assume instantiated to get args
     if args.command in ["start-worker", "start-control-plane"]:
         from .start import main
+    elif args.command == "down":
+        from .down import main
+    elif args.command == "wait-workers":
+        from .wait import main
+    elif args.command == "clean":
+        from .clean import main
+    elif args.command == "attr":
+        from .environment import attr_main as main
+    elif args.command == "env":
+        from .environment import env_main as main
+
+    # Develop mode, akin to commenting out the try/except below
+    if args.develop:
+        return main(args, extra)
     try:
         main(args, extra)
     except:

--- a/usernetes/cli/clean.py
+++ b/usernetes/cli/clean.py
@@ -1,0 +1,6 @@
+from usernetes.runner import UsernetesRunner
+
+
+def main(args, _):
+    runner = UsernetesRunner(workdir=args.workdir)
+    runner.clean(cache_only=not args.clean_all, keep_nodes=args.keep_node)

--- a/usernetes/cli/down.py
+++ b/usernetes/cli/down.py
@@ -1,0 +1,6 @@
+from usernetes.runner import UsernetesRunner
+
+
+def main(args, _):
+    runner = UsernetesRunner(workdir=args.workdir)
+    runner.down()

--- a/usernetes/cli/environment.py
+++ b/usernetes/cli/environment.py
@@ -1,0 +1,40 @@
+# These functions for environment and attributes assume
+# being in a flux instance, and also assume it is created
+# in the user temporary directory.
+import os
+
+import usernetes.instance as iutils
+
+
+def attributes(contenders):
+    """
+    Return unique (or default) attributes.
+    """
+    contenders = list(set(contenders))
+    if not contenders:
+        contenders = ["kubeconfig", "workdir"]
+    return contenders
+
+
+def attr_main(args, _):
+    """
+    Get (and print) one or more attributes
+    """
+    instance = iutils.InstanceAttributes()
+    for name in attributes(args.attributes):
+        attribute = getattr(instance, name, None)
+        if not attribute:
+            continue
+        print(attribute)
+
+
+def env_main(args, _):
+    """
+    Get (and print) one or more envars
+    """
+    instance = iutils.InstanceAttributes()
+    attribute_set = attributes(args.attributes)
+    if "kubeconfig" in attribute_set:
+        print(f"export KUBECONFIG={instance.kubeconfig}")
+    if "workdir" in args.attributes:
+        print(f"export USERNETES_WORKDIR={instance.workdir}")

--- a/usernetes/cli/start.py
+++ b/usernetes/cli/start.py
@@ -2,8 +2,10 @@ from usernetes.runner import UsernetesRunner
 
 
 def main(args, _):
-    runner = UsernetesRunner(args.config, workdir=args.workdir)
+    runner = UsernetesRunner(workdir=args.workdir)
     if args.command == "start-worker":
-        runner.start_worker(args)
+        runner.start_worker()
     else:
-        runner.start_control_plane(args)
+        if not args.worker_count:
+            raise ValueError("A --worker-count is required.")
+        runner.start_control_plane(args.worker_count, serial=args.serial)

--- a/usernetes/cli/wait.py
+++ b/usernetes/cli/wait.py
@@ -1,0 +1,8 @@
+from usernetes.runner import UsernetesRunner
+
+
+def main(args, _):
+    runner = UsernetesRunner(workdir=args.workdir)
+    runner.wait_for_workers(args.worker_count)
+    # We assume that new workers need a sync
+    runner.sync_external_ip()

--- a/usernetes/config/__init__.py
+++ b/usernetes/config/__init__.py
@@ -1,0 +1,1 @@
+from .config import ComposeConfig

--- a/usernetes/defaults.py
+++ b/usernetes/defaults.py
@@ -1,5 +1,3 @@
 import os
 
-here = os.path.dirname(__file__)
-usernetes_root = os.path.join(here, "src")
-compose_file = os.path.join(usernetes_root, "docker-compose.yaml")
+compose_file = "docker-compose.yaml"

--- a/usernetes/instance.py
+++ b/usernetes/instance.py
@@ -1,0 +1,44 @@
+# These functions for environment and attributes assume
+# being in a flux instance, and also assume it is created
+# in the user temporary directory.
+import os
+import tempfile
+
+import usernetes.utils as utils
+
+
+class InstanceAttributes:
+    def __init__(self):
+        self.jobid = get_jobid()
+        self.uid = f"usernetes-{self.jobid.lower()}"
+        self.root = os.path.join(tempfile.gettempdir(), self.uid)
+
+    @property
+    def kubeconfig(self):
+        return os.path.join(self.root, "kubeconfig")
+
+    @property
+    def workdir(self):
+        return self.root
+
+
+def get_jobid():
+    """
+    Get the job id, first from an attribute then environ.
+
+    This assumes flux, but arguably we can add other managers
+    or they can export a similar identifier.
+    """
+    # This only works in batch (not run/submit)
+    result = utils.run_command(["flux", "getattr", "jobid"])
+    if result["return_code"] == 0 and result["message"] is not None:
+        jobid = result["message"].strip()
+    else:
+        # Run/submit should have the envar
+        jobid = os.environ.get("FLUX_JOB_ID")
+    if jobid is None:
+        # Fall back to Slurm
+        jobid = os.environ.get("SLURM_JOB_ID")
+    if jobid is None:
+        raise ValueError("Cannot derive jobid to interact with.")
+    return jobid

--- a/usernetes/utils.py
+++ b/usernetes/utils.py
@@ -125,7 +125,7 @@ def run_command(cmd, stream=False, check_output=False, return_code=0, envars=Non
     If check_output is True, check against an expected return code.
     """
     envars = envars or {}
-    env = os.envion.copy()
+    env = os.environ.copy()
     env.update(envars)
     stdout = subprocess.PIPE if not stream else None
     output = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=stdout, env=env)

--- a/usernetes/version.py
+++ b/usernetes/version.py
@@ -1,16 +1,15 @@
-__version__ = "0.0.0"
+__version__ = "0.0.1"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "usernetes"
 PACKAGE_URL = "https://github.com/converged-computing/usernetes-python"
 KEYWORDS = "cluster, orchestration, user-space kubernetes, kubernetes, compose"
-DESCRIPTION = "Python SDK for user-space Kubernetes 'usernetes'"
+DESCRIPTION = "Python wrapper for user-space Kubernetes 'usernetes'"
 LICENSE = "LICENSE"
 
 ################################################################################
 # Global requirements
 
-INSTALL_REQUIRES = (("python-on-whales", {"min_version": None}),)
-
+INSTALL_REQUIRES = []
 TESTS_REQUIRES = (("pytest", {"min_version": "4.6.2"}),)
-INSTALL_REQUIRES_ALL = INSTALL_REQUIRES + TESTS_REQUIRES
+INSTALL_REQUIRES_ALL = TESTS_REQUIRES


### PR DESCRIPTION
This is the start of work for user space kubernetes to be deployed via flux via epilog/prolog scripts. I'll need to test this in full on an actual cluster, but I've been testing in pieces.

This first approach requires a shared filesystem (in tmp) as that is where we stage user space kubernetes. For our aws setups, I'm going to design a similar setup, but we will need to flux exec / archive the join-command over. The current aws base image does not have a more recent version of usernetes (it is missing the sync command) so I'm going to harden that up with an update that includes it, and likely add a packer build so I don't need to do it manually. 